### PR TITLE
feat: Add publish in local maven to testing.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
-apply plugin: 'java-library'
-apply plugin: 'maven-publish'
-apply plugin: 'signing'
+plugins {
+	id 'java-library'
+	id 'maven-publish'
+	id 'signing'
+}
+
 sourceCompatibility = 1.11
 def baseVersion = '3.9.4'
 def baseGroupId = 'io.github.adempiere'
@@ -40,23 +43,24 @@ java {
     withSourcesJar()
 }
 
-signing {
-    sign configurations.archives
-}
 
 def entityType = 'D'
-version = System.getenv("ADEMPIERE_LIBRARY_VERSION")
+def version = System.getenv("ADEMPIERE_LIBRARY_VERSION") ?: "local-1.0.0"
 
 jar {
     manifest {
-        attributes("Implementation-Title": "Adempiere Template Management",
-                   "Implementation-Version": version, 
-                   "EntityType": entityType)
+		attributes(
+			"Implementation-Title": "ADempiere Dashboard Improvements",
+			"Implementation-Version": version,
+			"EntityType": entityType
+		)
     }
 }
 
 publishing {
     repositories {
+		mavenLocal()
+
         maven {
             url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
             credentials {
@@ -99,10 +103,17 @@ publishing {
 }
 
 signing {
-    sign publishing.publications.mavenJava
-}
+	def isReleaseVersion = !version.toString().startsWith("local") && !version.toString().endsWith("-SNAPSHOT")
 
-signing {
+	sign configurations.archives
+
+	setRequired {
+		// signing is required if this is a release version and the artifacts are to be published
+		// do not use hasTask() as this require realization of the tasks that maybe are not necessary
+		isReleaseVersion && gradle.taskGraph.allTasks.any {
+			it.equals(PublishToMavenRepository)
+		}
+	}
 	def signingKey = findProperty("signingKey")
     def signingPassword = findProperty("signingPassword")
     useInMemoryPgpKeys(signingKey, signingPassword)


### PR DESCRIPTION
When publishing locally, artifact signing is omitted as always when the version starts with the prefix `local`, or ends with the suffix `SNAPSHOT`. Examples:
* `local-1.0.1`
* `1.0.1-SNAPSHOT`

This is for testing purposes only.


