### PR TITLE
fix: Get correct data source and set where.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,10 +45,11 @@ java {
 
 
 def entityType = 'D'
-def version = System.getenv("ADEMPIERE_LIBRARY_VERSION") ?: "local-1.0.0"
+group = "io.github.adempiere"
+version = System.getenv("ADEMPIERE_LIBRARY_VERSION") ?: "local-1.0.0"
 
 jar {
-    manifest {
+	manifest {
 		attributes(
 			"Implementation-Title": "ADempiere Dashboard Improvements",
 			"Implementation-Version": version,
@@ -71,9 +72,9 @@ publishing {
     }
     publications {
         mavenJava(MavenPublication) {
-        	groupId 'io.github.adempiere'
-            artifactId 'adempiere-dashboard-improvements'
-            version
+			groupId = group
+			artifactId = 'adempiere-dashboard-improvements'
+			version = version
            	from components.java
            	pom {
                 name = 'ADempiere Dashboard Improvements'
@@ -101,6 +102,12 @@ publishing {
 		}
 	}
 }
+
+
+task cleanBuildPublishLocal(type: GradleBuild) {
+	tasks = ['clean', 'build', 'publishToMavenLocal']
+}
+
 
 signing {
 	def isReleaseVersion = !version.toString().startsWith("local") && !version.toString().endsWith("-SNAPSHOT")

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'adempiere-dashboard-improvements'


### PR DESCRIPTION
When the id of the data source is different from the graph, it instantiates a non-existent data source with null values.

In addition, if the where clause had the word where first, it generated a query error.

also corrects the publication of versions.